### PR TITLE
test: use testthat + codecov

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,5 @@
 ^rgeopackage\.Rproj$
 ^\.Rproj\.user$
 ^LICENSE\.md$
+^codecov\.yml$
+^README\.Rmd$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,29 +2,30 @@ Package: rgeopackage
 Title: Helper Tools in Creating or Handling GeoPackage Files
 Version: 0.0.0.900
 Authors@R: c(
-    person(given = "Floris",
-           family = "Vanderhaeghe",
-           role = c("aut", "cre"),
-           email = "floris.vanderhaeghe@inbo.be",
+    person("Floris", "Vanderhaeghe", , "floris.vanderhaeghe@inbo.be", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6378-6229")),
-    person("Research Institute for Nature and Forest", 
-           email = "info@inbo.be", 
-           role = "cph"))
-Description: The aim of this R package is to provide helper tools in 
-    creating or handling GeoPackage files, in order to complement
-    other R spatial packages or GDAL. The package has no dependencies 
-    on other spatial packages and is not tied to any particular package 
-    by design.
+    person("Research Institute for Nature and Forest", , , "info@inbo.be", role = "cph"),
+    person("Eli", "Pousson", , "eli.pousson@gmail.com", role = "ctb",
+           comment = c(ORCID = "0000-0001-8280-1706"))
+  )
+Description: The aim of this R package is to provide helper tools in
+    creating or handling GeoPackage files, in order to complement other R
+    spatial packages or GDAL. The package has no dependencies on other
+    spatial packages and is not tied to any particular package by design.
 License: GPL (>= 3)
 Depends: 
     R (>= 3.1.0)
 Suggests:
+    covr,
     dplyr,
     openssl,
     RSQLite,
     sf,
-    stars
+    stars,
+    testthat (>= 3.0.0),
+    withr
+Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.1

--- a/R/rgeopackage-package.R
+++ b/R/rgeopackage-package.R
@@ -1,0 +1,6 @@
+#' @keywords internal
+"_PACKAGE"
+
+## usethis namespace: start
+## usethis namespace: end
+NULL

--- a/R/timestamp.R
+++ b/R/timestamp.R
@@ -50,38 +50,38 @@
 #'
 #' # A rewrite changes the checksum:
 #' filepath_notimeset <- file.path(tempdir(), "b_pump_notimeset.gpkg")
-#'   # write 1:
+#' # write 1:
 #' st_write(sf_layer, dsn = filepath_notimeset, delete_dsn = TRUE)
 #' (md5_notimeset1 <- md5sum(filepath_notimeset))
-#'   # write 2:
+#' # write 2:
 #' st_write(sf_layer, dsn = filepath_notimeset, delete_dsn = TRUE)
 #' (md5_notimeset2 <- md5sum(filepath_notimeset))
-#'   # compare:
+#' # compare:
 #' md5_notimeset1 == md5_notimeset2
 #'
 #' # Setting a fixed date
 #' filepath_timeset <- file.path(tempdir(), "b_pump_timeset.gpkg")
 #' (fixed_date <- as.Date("2020-12-25"))
 #' preset_timestamp(fixed_date)
-#'   # write 1 (date):
+#' # write 1 (date):
 #' st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 #' md5_timeset1 <- md5sum(filepath_timeset)
-#'   # write 2 (date):
+#' # write 2 (date):
 #' st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 #' md5_timeset2 <- md5sum(filepath_timeset)
-#'   # compare:
+#' # compare:
 #' all.equal(md5_timeset1, md5_timeset2)
 #'
 #' # Setting a fixed time
 #' (fixed_time <- as.POSIXct("2020-12-25 12:00:00", tz = "CET"))
 #' preset_timestamp(fixed_time)
-#'   # write 3 (time):
+#' # write 3 (time):
 #' st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 #' md5_timeset3 <- md5sum(filepath_timeset)
-#'   # write 4 (time):
+#' # write 4 (time):
 #' st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 #' md5_timeset4 <- md5sum(filepath_timeset)
-#'   # compare:
+#' # compare:
 #' all.equal(md5_timeset3, md5_timeset4)
 #'
 #' # Also works for GPKG 2D gridded coverage (with stars):
@@ -93,36 +93,37 @@
 #' preset_timestamp(fixed_time)
 #'
 #' stars_2d <-
-#' 	system.file("tif/L7_ETMs.tif", package = "stars") %>%
-#' 	read_stars() %>%
-#' 	slice(band, 1)
-#'   # write 1:
+#'   system.file("tif/L7_ETMs.tif", package = "stars") %>%
+#'   read_stars() %>%
+#'   slice(band, 1)
+#' # write 1:
 #' stars_2d %>%
-#' 	write_stars(filepath_stars, driver = "GPKG")
+#'   write_stars(filepath_stars, driver = "GPKG")
 #' md5_stars1 <- md5sum(filepath_stars)
-#'   # write 2:
+#' # write 2:
 #' stars_2d %>%
-#' 	write_stars(filepath_stars, driver = "GPKG")
+#'   write_stars(filepath_stars, driver = "GPKG")
 #' md5_stars2 <- md5sum(filepath_stars)
-#'   # compare:
+#' # compare:
 #' all.equal(md5_stars1, md5_stars2)
 #'
 #' @author Floris Vanderhaeghe, \url{https://github.com/florisvdh}
 #'
 #' @export
 preset_timestamp <- function(timestamp) {
-	if (!inherits(timestamp, c("Date", "POSIXct"))) {
-		stop("timestamp must be a Date or POSIXct object")
-	}
+  if (!inherits(timestamp, c("Date", "POSIXct"))) {
+    stop("timestamp must be a Date or POSIXct object")
+  }
 
-	timestamp <- format(timestamp,
-						format = "%Y-%m-%dT%H:%M:%S.000Z",
-						tz = "UTC")
+  timestamp <- format(timestamp,
+    format = "%Y-%m-%dT%H:%M:%S.000Z",
+    tz = "UTC"
+  )
 
-	old <- Sys.getenv("OGR_CURRENT_DATE")
-	Sys.setenv(OGR_CURRENT_DATE = timestamp)
+  old <- Sys.getenv("OGR_CURRENT_DATE")
+  Sys.setenv(OGR_CURRENT_DATE = timestamp)
 
-	return(invisible(old))
+  return(invisible(old))
 }
 
 
@@ -130,19 +131,6 @@ preset_timestamp <- function(timestamp) {
 #' @rdname preset_timestamp
 #' @export
 unset_timestamp <- function() Sys.unsetenv("OGR_CURRENT_DATE")
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -198,40 +186,40 @@ unset_timestamp <- function() Sys.unsetenv("OGR_CURRENT_DATE")
 #'
 #' # A rewrite changes the checksum:
 #' filepath_notimeset <- file.path(tempdir(), "b_pump_notimeset.gpkg")
-#'   # write 1:
+#' # write 1:
 #' st_write(sf_layer, dsn = filepath_notimeset, delete_dsn = TRUE)
 #' (md5_notimeset1 <- md5sum(filepath_notimeset))
-#'   # write 2:
+#' # write 2:
 #' st_write(sf_layer, dsn = filepath_notimeset, delete_dsn = TRUE)
 #' (md5_notimeset2 <- md5sum(filepath_notimeset))
-#'   # compare:
+#' # compare:
 #' md5_notimeset1 == md5_notimeset2
 #'
 #' # Setting a fixed date
 #' filepath_timeset <- file.path(tempdir(), "b_pump_timeset.gpkg")
 #' (fixed_date <- as.Date("2020-12-25"))
-#'   # write 1 (date):
+#' # write 1 (date):
 #' st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 #' amend_timestamp(filepath_timeset, fixed_date)
 #' md5_timeset1 <- md5sum(filepath_timeset)
-#'   # write 2 (date):
+#' # write 2 (date):
 #' st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 #' amend_timestamp(filepath_timeset, fixed_date)
 #' md5_timeset2 <- md5sum(filepath_timeset)
-#'   # compare:
+#' # compare:
 #' all.equal(md5_timeset1, md5_timeset2)
 #'
 #' # Setting a fixed time
 #' (fixed_time <- as.POSIXct("2020-12-25 12:00:00", tz = "CET"))
-#'   # write 3 (time):
+#' # write 3 (time):
 #' st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 #' amend_timestamp(filepath_timeset, fixed_time)
 #' md5_timeset3 <- md5sum(filepath_timeset)
-#'   # write 4 (time):
+#' # write 4 (time):
 #' st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 #' amend_timestamp(filepath_timeset, fixed_time)
 #' md5_timeset4 <- md5sum(filepath_timeset)
-#'   # compare:
+#' # compare:
 #' all.equal(md5_timeset3, md5_timeset4)
 #'
 #' # Also works for GPKG 2D gridded coverage (with stars):
@@ -241,20 +229,20 @@ unset_timestamp <- function() Sys.unsetenv("OGR_CURRENT_DATE")
 #' filepath_stars <- file.path(tempdir(), "stars_2d.gpkg")
 #'
 #' stars_2d <-
-#' 	system.file("tif/L7_ETMs.tif", package = "stars") %>%
-#' 	read_stars() %>%
-#' 	slice(band, 1)
-#'   # write 1:
+#'   system.file("tif/L7_ETMs.tif", package = "stars") %>%
+#'   read_stars() %>%
+#'   slice(band, 1)
+#' # write 1:
 #' stars_2d %>%
-#' 	write_stars(filepath_stars, driver = "GPKG")
+#'   write_stars(filepath_stars, driver = "GPKG")
 #' amend_timestamp(filepath_stars, fixed_time)
 #' md5_stars1 <- md5sum(filepath_stars)
-#'   # write 2:
+#' # write 2:
 #' stars_2d %>%
-#' 	write_stars(filepath_stars, driver = "GPKG")
+#'   write_stars(filepath_stars, driver = "GPKG")
 #' amend_timestamp(filepath_stars, fixed_time)
 #' md5_stars2 <- md5sum(filepath_stars)
-#'   # compare:
+#' # compare:
 #' all.equal(md5_stars1, md5_stars2)
 #'
 #' @author Floris Vanderhaeghe, \url{https://github.com/florisvdh}
@@ -263,54 +251,62 @@ unset_timestamp <- function() Sys.unsetenv("OGR_CURRENT_DATE")
 amend_timestamp <- function(dsn,
                             timestamp = Sys.time(),
                             verbose = TRUE) {
-    stopifnot(file.exists(dsn))
-    stopifnot(is.logical(verbose), !is.na(verbose))
-    # soft checking file format:
-    if (!grepl("\\.gpkg$", dsn)) {
-        stop("Expecting a file with extension '.gpkg'")
-    }
-    if (!inherits(timestamp, c("Date", "POSIXct"))) {
-        stop("timestamp must be a Date or POSIXct object")
-    }
+  stopifnot(file.exists(dsn))
+  stopifnot(is.logical(verbose), !is.na(verbose))
+  # soft checking file format:
+  if (!grepl("\\.gpkg$", dsn)) {
+    stop("Expecting a file with extension '.gpkg'")
+  }
+  if (!inherits(timestamp, c("Date", "POSIXct"))) {
+    stop("timestamp must be a Date or POSIXct object")
+  }
 
-    if (!requireNamespace("RSQLite", quietly = TRUE)) {
-        stop("Package \"RSQLite\" is needed when using this function. ",
-             "Please install it.",
-             call. = FALSE)
-    }
+  if (!requireNamespace("RSQLite", quietly = TRUE)) {
+    stop("Package \"RSQLite\" is needed when using this function. ",
+      "Please install it.",
+      call. = FALSE
+    )
+  }
 
-    timestamp <- format(timestamp,
-                        format = "%Y-%m-%dT%H:%M:%S.000Z",
-                        tz = "UTC")
+  timestamp <- format(timestamp,
+    format = "%Y-%m-%dT%H:%M:%S.000Z",
+    tz = "UTC"
+  )
 
-    con <- RSQLite::dbConnect(RSQLite::SQLite(), dsn)
-    updatequery <- sprintf("UPDATE gpkg_contents SET last_change = '%s'",
-                           timestamp)
+  con <- RSQLite::dbConnect(RSQLite::SQLite(), dsn)
+  updatequery <- sprintf(
+    "UPDATE gpkg_contents SET last_change = '%s'",
+    timestamp
+  )
+  rows <- RSQLite::dbExecute(con, updatequery)
+  if (verbose) {
+    message(
+      rows,
+      " row(s) of the gpkg_contents table have been set with timestamp ",
+      timestamp
+    )
+  }
+
+  has_metadata <-
+    nrow(RSQLite::dbGetQuery(con, "SELECT name FROM sqlite_master
+						WHERE name == 'gpkg_metadata_reference'")) > 0
+  if (has_metadata) {
+    updatequery <-
+      sprintf(
+        "UPDATE gpkg_metadata_reference SET timestamp = '%s'",
+        timestamp
+      )
     rows <- RSQLite::dbExecute(con, updatequery)
     if (verbose) {
-        message(
-            rows,
-            " row(s) of the gpkg_contents table have been set with timestamp ",
-            timestamp)
+      message(
+        rows,
+        " row(s) of the gpkg_metadata_reference table have ",
+        "been set with timestamp ",
+        timestamp
+      )
     }
+  }
 
-    has_metadata <-
-        nrow(RSQLite::dbGetQuery(con, "SELECT name FROM sqlite_master
-						WHERE name == 'gpkg_metadata_reference'")) > 0
-    if (has_metadata) {
-        updatequery <-
-            sprintf("UPDATE gpkg_metadata_reference SET timestamp = '%s'",
-                    timestamp)
-        rows <- RSQLite::dbExecute(con, updatequery)
-        if (verbose) {
-            message(
-                rows,
-                " row(s) of the gpkg_metadata_reference table have ",
-                "been set with timestamp ",
-                timestamp)
-        }
-    }
-
-    RSQLite::dbDisconnect(con)
-    return(invisible(NULL))
+  RSQLite::dbDisconnect(con)
+  return(invisible(NULL))
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,7 +42,7 @@ remotes::install_github("r-spatial/rgeopackage")
 The timestamp is adopted by GDAL during the entire session, unless `unset_timestamp()` is called.
 - `amend_timestamp()`: overwrites timestamps in the `gpkg_contents` and `gpkg_metadata_reference` tables of an existing GeoPackage file.
 
-By default, GDAL sets timestamps corresponding to system time, so GeoPackages change when rewriting. Both functions accept a `Date` or `POSIXct` object and use standard formatting for GeoPackage files.
+By default, GDAL sets timestamps corresponding to system time, so GeoPackages change when rewriting. Both functions accept a `Date` or `POSIXct` object and reformat to comply with the GeoPackage standard.
 
 ## Related R packages
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -27,7 +27,7 @@ More generally, it aims to provide features not readily available in mainstream 
 
 ## Installation
 
-You can install the development version of rgeopackage from [GitHub](https://github.com/) with:
+You can install the development version of `rgeopackage` from [GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("devtools")

--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,8 @@ knitr::opts_chunk$set(
 [![Codecov test coverage](https://codecov.io/gh/r-spatial/rgeopackage/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-spatial/rgeopackage?branch=main)
 <!-- badges: end -->
 
-The goal of rgeopackage is to support reading and writing metadata associated with GeoPackage (gpkg) files and assist in writing reproducible GeoPackage files.
+The current goal of `rgeopackage` is to support reading and writing metadata associated with GeoPackage (gpkg) files and assist in writing reproducible GeoPackage files.
+More generally, it aims to provide features not readily available in mainstream geospatial R packages, or perhaps uneasy to discover.
 
 ## Installation
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -31,7 +31,7 @@ You can install the development version of rgeopackage from [GitHub](https://git
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("r-spatial/rgeopackage")
+remotes::install_github("r-spatial/rgeopackage")
 ```
 
 ## Overview

--- a/README.Rmd
+++ b/README.Rmd
@@ -45,6 +45,6 @@ By default, GDAL sets timestamps corresponding to system time, so GeoPackages ch
 
 ## Related R packages
 
-- The [sf package](https://r-spatial.github.io/sf/) allows users to set GDAL configuration options in `sf::st_write()` using the `config_options` argument ([see sf issue #1618](https://github.com/r-spatial/sf/issues/1618#issuecomment-811231056)) and in `sf::st_read()` using the `options` argument (see [sf issue 1157](https://github.com/r-spatial/sf/issues/1157)). sf also includes a set of GDAL functions (e.g. `sf::gdal_metadata()`) that are not intended to be called directly by the user but could be used to access and edit GeoPackage metadata.
+- The [`sf` package](https://r-spatial.github.io/sf/) allows users to set GDAL configuration options in `sf::st_write()` using the `config_options` argument ([see sf issue #1618](https://github.com/r-spatial/sf/issues/1618#issuecomment-811231056)) and in `sf::st_read()` using the `options` argument (see [sf issue 1157](https://github.com/r-spatial/sf/issues/1157)). These options only affect the specific read or write statement and do not persist during the session. `sf` also includes a set of GDAL functions (e.g. `sf::gdal_metadata()`) that are not intended to be called directly by the user but could be used to access and edit GeoPackage metadata.
 
-- The [vapour package](https://hypertidy.github.io/vapour/index.html) provides access to the basic read functions available in GDAL including GeoPackage contents and extension tables.
+- The [`vapour` package](https://hypertidy.github.io/vapour/index.html) provides access to the basic read functions available in GDAL including GeoPackage contents and extension tables.

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,50 @@
+---
+output: github_document
+---
+
+<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "man/figures/README-",
+  out.width = "100%"
+)
+```
+
+# rgeopackage
+
+<!-- badges: start -->
+[![CRAN status](https://www.r-pkg.org/badges/version/rgeopackage)](https://CRAN.R-project.org/package=rgeopackage)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![Codecov test coverage](https://codecov.io/gh/r-spatial/rgeopackage/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-spatial/rgeopackage?branch=main)
+<!-- badges: end -->
+
+The goal of rgeopackage is to support reading and writing metadata associated with GeoPackage (gpkg) files and assist in writing reproducible GeoPackage files.
+
+## Installation
+
+You can install the development version of rgeopackage from [GitHub](https://github.com/) with:
+
+``` r
+# install.packages("devtools")
+devtools::install_github("r-spatial/rgeopackage")
+```
+
+## Overview
+
+### Updating file timestamps
+
+- `preset_timestamp()`: presets the file timestamp for usage by GDAL by setting the environment variable `OGR_CURRENT_DATE`.
+The timestamp is adopted by GDAL during the entire session, unless `unset_timestamp()` is called.
+- `amend_timestamp()`: overwrites timestamps in the `gpkg_contents` and `gpkg_metadata_reference` tables of an existing GeoPackage file.
+
+By default, GDAL sets timestamps corresponding to system time, so GeoPackages change when rewriting. Both functions accept a `Date` or `POSIXct` object and use standard formatting for GeoPackage files.
+
+## Related R packages
+
+- The [sf package](https://r-spatial.github.io/sf/) allows users to set GDAL configuration options in `sf::st_write()` using the `config_options` argument ([see sf issue #1618](https://github.com/r-spatial/sf/issues/1618#issuecomment-811231056)) and in `sf::st_read()` using the `options` argument (see [sf issue 1157](https://github.com/r-spatial/sf/issues/1157)). sf also includes a set of GDAL functions (e.g. `sf::gdal_metadata()`) that are not intended to be called directly by the user but could be used to access and edit GeoPackage metadata.
+
+- The [vapour package](https://hypertidy.github.io/vapour/index.html) provides access to the basic read functions available in GDAL including GeoPackage contents and extension tables.

--- a/README.md
+++ b/README.md
@@ -1,51 +1,61 @@
-## Helper tools to work with GeoPackage files in R
 
-### Functionality
+<!-- README.md is generated from README.Rmd. Please edit that file -->
 
-The package currently provides following functions that assist in writing reproducible GeoPackage files:
+# rgeopackage
 
-- `preset_timestamp()`: presets the file timestamp for usage by GDAL by setting the environment variable `OGR_CURRENT_DATE`.
-The timestamp is adopted by GDAL during the entire session, unless `unset_timestamp()` is called.
-- `amend_timestamp()`: overwrites timestamps in the `gpkg_contents` and `gpkg_metadata_reference` tables of an existing GeoPackage file.
-While directly editing a GeoPackage is not advised, this function is especially useful in the presence of the optional table `gpkg_metadata_reference`, as GDAL does not control its timestamps as of writing (for GDAL 3.1.3).
-See a corresponding [issue](https://github.com/OSGeo/gdal/issues/3537) in the GDAL source repository.
+<!-- badges: start -->
 
-By default, GDAL sets timestamps corresponding to system time, so GeoPackages change when rewriting.
+[![CRAN
+status](https://www.r-pkg.org/badges/version/rgeopackage)](https://CRAN.R-project.org/package=rgeopackage)
+[![License: GPL
+v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Lifecycle:
+experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![Codecov test
+coverage](https://codecov.io/gh/r-spatial/rgeopackage/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-spatial/rgeopackage?branch=main)
+<!-- badges: end -->
 
-Both functions accept a `Date` or `POSIXct` object and format the timestamp in order to comply with the GeoPackage requirement.
-See the functions' documentation and examples to get a better understanding.
+The goal of rgeopackage is to support reading and writing metadata
+associated with GeoPackage (gpkg) files and assist in writing
+reproducible GeoPackage files.
 
-### Installation
+## Installation
 
-```r
-remotes::install_github("r-spatial/rgeopackage")
+You can install the development version of rgeopackage from
+[GitHub](https://github.com/) with:
+
+``` r
+# install.packages("devtools")
+devtools::install_github("r-spatial/rgeopackage")
 ```
 
-### Untied to other packages
+## Overview
 
-`rgeopackage` has no dependencies on other spatial packages and is not tied to any particular package by design.
+### Updating file timestamps
 
-### Related functionality in core spatial R packages
+- `preset_timestamp()`: presets the file timestamp for usage by GDAL by
+  setting the environment variable `OGR_CURRENT_DATE`. The timestamp is
+  adopted by GDAL during the entire session, unless `unset_timestamp()`
+  is called.
+- `amend_timestamp()`: overwrites timestamps in the `gpkg_contents` and
+  `gpkg_metadata_reference` tables of an existing GeoPackage file.
 
-- `sf::st_write()` is [now able to](https://github.com/r-spatial/sf/issues/1618#issuecomment-811231056) set GDAL configuration options through its `config_options` argument.
-So when using `sf` you can pass the timestamp on a per-write basis:
+By default, GDAL sets timestamps corresponding to system time, so
+GeoPackages change when rewriting. Both functions accept a `Date` or
+`POSIXct` object and use standard formatting for GeoPackage files.
 
-  ```r
-  library(sf)
-  nc <- st_read(system.file('shape/nc.shp', package = 'sf'), quiet = TRUE)
-  fixed_time <- as.POSIXct("2020-12-25 12:00:00", tz = "CET")
-  # or using a Date object:
-  # fixed_time <- as.Date("2020-12-25")
-  timestamp <- format(fixed_time, format = "%Y-%m-%dT%H:%M:%S.000Z", tz = "UTC")
-  st_write(nc, 'nc.gpkg', config_options = c(OGR_CURRENT_DATE = timestamp))
-  ```
-  
-  Note that this does not affect the value of the environment variable `OGR_CURRENT_DATE`: `config_options = c(OGR_CURRENT_DATE = timestamp)` directly sets the GDAL `OGR_CURRENT_DATE` _configuration option_ which, if unset, inherits from the `OGR_CURRENT_DATE` environment variable.
-Also, note that `st_write()` ends by unsetting the configuration option, so set it in each `st_write()` statement as needed.
-  
-  In this case please take care to format the timestamp exactly as required by the GeoPackage standard; cf. example above and [Requirement 15](https://www.geopackage.org/spec120/#r15) in version 1.2.
-  
-- for packages relying on `rgdal` - like `sp` - it should be possible to set `OGR_CURRENT_DATE` by using `rgdal::setCPLConfigOption()` before doing the write operation.
-Again, take care to format the timestamp exactly as required by the GeoPackage standard.
+## Related R packages
 
+- The [sf package](https://r-spatial.github.io/sf/) allows users to set
+  GDAL configuration options in `sf::st_write()` using the
+  `config_options` argument ([see sf issue
+  \#1618](https://github.com/r-spatial/sf/issues/1618#issuecomment-811231056))
+  and in `sf::st_read()` using the `options` argument (see [sf issue
+  1157](https://github.com/r-spatial/sf/issues/1157)). sf also includes
+  a set of GDAL functions (e.g. `sf::gdal_metadata()`) that are not
+  intended to be called directly by the user but could be used to access
+  and edit GeoPackage metadata.
 
+- The [vapour package](https://hypertidy.github.io/vapour/index.html)
+  provides access to the basic read functions available in GDAL
+  including GeoPackage contents and extension tables.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true

--- a/man/amend_timestamp.Rd
+++ b/man/amend_timestamp.Rd
@@ -56,40 +56,40 @@ sf_layer <- read_sf(system.file("gpkg/b_pump.gpkg", package = "sf"))
 
 # A rewrite changes the checksum:
 filepath_notimeset <- file.path(tempdir(), "b_pump_notimeset.gpkg")
-  # write 1:
+# write 1:
 st_write(sf_layer, dsn = filepath_notimeset, delete_dsn = TRUE)
 (md5_notimeset1 <- md5sum(filepath_notimeset))
-  # write 2:
+# write 2:
 st_write(sf_layer, dsn = filepath_notimeset, delete_dsn = TRUE)
 (md5_notimeset2 <- md5sum(filepath_notimeset))
-  # compare:
+# compare:
 md5_notimeset1 == md5_notimeset2
 
 # Setting a fixed date
 filepath_timeset <- file.path(tempdir(), "b_pump_timeset.gpkg")
 (fixed_date <- as.Date("2020-12-25"))
-  # write 1 (date):
+# write 1 (date):
 st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 amend_timestamp(filepath_timeset, fixed_date)
 md5_timeset1 <- md5sum(filepath_timeset)
-  # write 2 (date):
+# write 2 (date):
 st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 amend_timestamp(filepath_timeset, fixed_date)
 md5_timeset2 <- md5sum(filepath_timeset)
-  # compare:
+# compare:
 all.equal(md5_timeset1, md5_timeset2)
 
 # Setting a fixed time
 (fixed_time <- as.POSIXct("2020-12-25 12:00:00", tz = "CET"))
-  # write 3 (time):
+# write 3 (time):
 st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 amend_timestamp(filepath_timeset, fixed_time)
 md5_timeset3 <- md5sum(filepath_timeset)
-  # write 4 (time):
+# write 4 (time):
 st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 amend_timestamp(filepath_timeset, fixed_time)
 md5_timeset4 <- md5sum(filepath_timeset)
-  # compare:
+# compare:
 all.equal(md5_timeset3, md5_timeset4)
 
 # Also works for GPKG 2D gridded coverage (with stars):
@@ -99,20 +99,20 @@ library(dplyr)
 filepath_stars <- file.path(tempdir(), "stars_2d.gpkg")
 
 stars_2d <-
-	system.file("tif/L7_ETMs.tif", package = "stars") \%>\%
-	read_stars() \%>\%
-	slice(band, 1)
-  # write 1:
+  system.file("tif/L7_ETMs.tif", package = "stars") \%>\%
+  read_stars() \%>\%
+  slice(band, 1)
+# write 1:
 stars_2d \%>\%
-	write_stars(filepath_stars, driver = "GPKG")
+  write_stars(filepath_stars, driver = "GPKG")
 amend_timestamp(filepath_stars, fixed_time)
 md5_stars1 <- md5sum(filepath_stars)
-  # write 2:
+# write 2:
 stars_2d \%>\%
-	write_stars(filepath_stars, driver = "GPKG")
+  write_stars(filepath_stars, driver = "GPKG")
 amend_timestamp(filepath_stars, fixed_time)
 md5_stars2 <- md5sum(filepath_stars)
-  # compare:
+# compare:
 all.equal(md5_stars1, md5_stars2)
 
 }

--- a/man/preset_timestamp.Rd
+++ b/man/preset_timestamp.Rd
@@ -55,38 +55,38 @@ sf_layer <- read_sf(system.file("gpkg/b_pump.gpkg", package = "sf"))
 
 # A rewrite changes the checksum:
 filepath_notimeset <- file.path(tempdir(), "b_pump_notimeset.gpkg")
-  # write 1:
+# write 1:
 st_write(sf_layer, dsn = filepath_notimeset, delete_dsn = TRUE)
 (md5_notimeset1 <- md5sum(filepath_notimeset))
-  # write 2:
+# write 2:
 st_write(sf_layer, dsn = filepath_notimeset, delete_dsn = TRUE)
 (md5_notimeset2 <- md5sum(filepath_notimeset))
-  # compare:
+# compare:
 md5_notimeset1 == md5_notimeset2
 
 # Setting a fixed date
 filepath_timeset <- file.path(tempdir(), "b_pump_timeset.gpkg")
 (fixed_date <- as.Date("2020-12-25"))
 preset_timestamp(fixed_date)
-  # write 1 (date):
+# write 1 (date):
 st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 md5_timeset1 <- md5sum(filepath_timeset)
-  # write 2 (date):
+# write 2 (date):
 st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 md5_timeset2 <- md5sum(filepath_timeset)
-  # compare:
+# compare:
 all.equal(md5_timeset1, md5_timeset2)
 
 # Setting a fixed time
 (fixed_time <- as.POSIXct("2020-12-25 12:00:00", tz = "CET"))
 preset_timestamp(fixed_time)
-  # write 3 (time):
+# write 3 (time):
 st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 md5_timeset3 <- md5sum(filepath_timeset)
-  # write 4 (time):
+# write 4 (time):
 st_write(sf_layer, dsn = filepath_timeset, delete_dsn = TRUE)
 md5_timeset4 <- md5sum(filepath_timeset)
-  # compare:
+# compare:
 all.equal(md5_timeset3, md5_timeset4)
 
 # Also works for GPKG 2D gridded coverage (with stars):
@@ -98,18 +98,18 @@ filepath_stars <- file.path(tempdir(), "stars_2d.gpkg")
 preset_timestamp(fixed_time)
 
 stars_2d <-
-	system.file("tif/L7_ETMs.tif", package = "stars") \%>\%
-	read_stars() \%>\%
-	slice(band, 1)
-  # write 1:
+  system.file("tif/L7_ETMs.tif", package = "stars") \%>\%
+  read_stars() \%>\%
+  slice(band, 1)
+# write 1:
 stars_2d \%>\%
-	write_stars(filepath_stars, driver = "GPKG")
+  write_stars(filepath_stars, driver = "GPKG")
 md5_stars1 <- md5sum(filepath_stars)
-  # write 2:
+# write 2:
 stars_2d \%>\%
-	write_stars(filepath_stars, driver = "GPKG")
+  write_stars(filepath_stars, driver = "GPKG")
 md5_stars2 <- md5sum(filepath_stars)
-  # compare:
+# compare:
 all.equal(md5_stars1, md5_stars2)
 
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/tests.html
+# * https://testthat.r-lib.org/reference/test_package.html#special-files
+
+library(testthat)
+library(rgeopackage)
+
+test_check("rgeopackage")

--- a/tests/testthat/test-timestamp.R
+++ b/tests/testthat/test-timestamp.R
@@ -1,0 +1,13 @@
+test_that("amend_timestamp works", {
+  nc <- sf::st_read(system.file("shape/nc.shp", package = "sf"))
+  withr::with_tempfile(
+    "nc.gpkg",
+    {
+      sf::write_sf(nc, "nc.gpkg")
+      expect_message(
+        amend_timestamp("nc.gpkg"),
+        "gpkg_contents table have been set with timestamp"
+      )
+    }
+  )
+})


### PR DESCRIPTION
These are all fairly basic changes to start addressing #5 and #6:

- test: use testthat + codecov
- test: add test for amend_timestamp
- docs: switch to Rmd for README + revise README + add package docs
- docs: add Eli Pousson to contributors
- refactor: add testthat, withr, and covr packages to Suggests
- style: style timestamp.R

I can set up a GitHub action with `use_github_action("test-coverage")` on main once this is merged.